### PR TITLE
Fix NullReferenceException in android CarouselViewRenderer

### DIFF
--- a/CarouselView.Maui/Platforms/Android/CarouselViewRenderer.cs
+++ b/CarouselView.Maui/Platforms/Android/CarouselViewRenderer.cs
@@ -138,7 +138,10 @@ namespace CarouselView.Droid
                 }
 
                 // KeyboardService code
-                Application.Current.MainPage.SizeChanged += MainPage_SizeChanged;
+                if(Application.Current?.MainPage != null) 
+                {
+                    Application.Current.MainPage.SizeChanged += MainPage_SizeChanged;
+                }
 
                 // Nullreference exception on external display #409
                 if (keyboardService != null)


### PR DESCRIPTION
When the CarouselView is used in an .Net for Android application the MainPage might be null which results in a NullReferenceException. This PR prevents the app from crashsing in this case.