### PR TITLE
Add IgnoreSafeArea property to CarouselViewControl

### DIFF
--- a/CarouselView.Maui/Abstractions/CarouselViewControl.cs
+++ b/CarouselView.Maui/Abstractions/CarouselViewControl.cs
@@ -115,6 +115,14 @@ namespace CarouselView.Abstractions
             set { SetValue(AutoplayIntervalProperty, value); }
         }
 
+        public static readonly BindableProperty IgnoreSafeAreaProperty = BindableProperty.Create("IgnoreSafeArea", typeof(bool), typeof(CarouselViewControl), true);
+
+        public bool IgnoreSafeArea
+        {
+            get { return (bool)GetValue(IgnoreSafeAreaProperty); }
+            set { SetValue(IgnoreSafeAreaProperty, value); }
+        }
+
         #region Indicators
 
         public static readonly BindableProperty IndicatorsTintColorProperty = BindableProperty.Create("IndicatorsTintColor", typeof(Color), typeof(CarouselViewControl), Colors.Silver);

--- a/CarouselView.Maui/Platforms/iOS/CarouselViewRenderer.cs
+++ b/CarouselView.Maui/Platforms/iOS/CarouselViewRenderer.cs
@@ -66,7 +66,7 @@ namespace CarouselView.iOS
             //Reset safeAreaInsets to UIEdgeInsets.Zero
             if (pageController == null || pageController.View == null) { return; }
             var safeAreaInsets = pageController.View.SafeAreaInsets;
-            if (safeAreaInsets != UIEdgeInsets.Zero)
+            if (safeAreaInsets != UIEdgeInsets.Zero && Element.IgnoreSafeArea)
             {
                 pageController.AdditionalSafeAreaInsets = new UIEdgeInsets(-safeAreaInsets.Top, -safeAreaInsets.Left, -safeAreaInsets.Bottom, -safeAreaInsets.Right);
             }


### PR DESCRIPTION
To be able to control whether the iOS safe area padding should be ignored or not, e.g. when the carousel item is a webview.